### PR TITLE
Fixing redix mget filter and tests

### DIFF
--- a/lib/brook.ex
+++ b/lib/brook.ex
@@ -2,7 +2,7 @@ defmodule Brook do
   @type event_type :: String.t()
   @type event :: term()
 
-  @type view_collection :: String.Chard.t()
+  @type view_collection :: String.Chars.t()
   @type view_key :: String.Chars.t()
   @type view_value :: term()
 

--- a/test/integration/brook_integration_test.exs
+++ b/test/integration/brook_integration_test.exs
@@ -47,7 +47,7 @@ defmodule Brook.IntegrationTest do
     Elsa.produce([localhost: 9092], "test", {"UPDATE_APP_STATE", Jason.encode!(%{"name" => "app_state"})})
 
     assert_async(timeout: 2_000, sleep_time: 200) do
-      assert %{"id" => 123, "name" => "George", "age" => 67} == Brook.get(:all, 123)
+      assert {:ok, %{"id" => 123, "name" => "George", "age" => 67}} == Brook.get(:all, 123)
     end
 
     assert_async(timeout: 2_000, sleep_time: 200) do
@@ -60,7 +60,7 @@ defmodule Brook.IntegrationTest do
     end
 
     assert_async(timeout: 2_000, sleep_time: 200) do
-      events = Brook.get_events(:all, 123)
+      {:ok, events} = Brook.get_events(:all, 123)
       assert 2 == length(events)
 
       create_event = List.first(events)
@@ -75,7 +75,7 @@ defmodule Brook.IntegrationTest do
     Elsa.produce([localhost: 9092], "test", {"DELETE", Jason.encode!(%{"id" => 123})})
 
     assert_async(timeout: 2_000, sleep_time: 200) do
-      assert nil == Brook.get(:all, 123)
+      assert {:ok, nil} == Brook.get(:all, 123)
     end
 
     assert_async(timeout: 2_000, sleep_time: 200) do


### PR DESCRIPTION
Not sure why the `get_all` function in the redis-based integration test is passing (after updating the function calls to return the tuple-wrapped results but this should fix that issue and the typo in the typespec.