### PR TITLE
Switch the default driver to call instead of cast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ erl_crash.dump
 brook-*.tar
 
 .DS_Store
+
+.elixir_ls

--- a/lib/brook/driver.ex
+++ b/lib/brook/driver.ex
@@ -58,7 +58,7 @@ defmodule Brook.Driver.Default do
   @impl Brook.Driver
   def send_event(instance, _type, event) do
     registry = Brook.Config.registry(instance)
-    GenServer.cast({:via, Registry, {registry, Brook.Server}}, {:process, event})
+    GenServer.call({:via, Registry, {registry, Brook.Server}}, {:process, event})
 
     :ok
   end

--- a/lib/brook/test.ex
+++ b/lib/brook/test.ex
@@ -24,7 +24,9 @@ defmodule Brook.Test do
   def clear_view_state(instance, collection) do
     storage = Brook.Config.storage(instance)
 
-    apply(storage.module, :get_all, [instance, collection])
+    {:ok, entries} = apply(storage.module, :get_all, [instance, collection])
+
+    entries
     |> Enum.each(fn {key, _value} ->
       apply(storage.module, :delete, [instance, collection, key])
     end)


### PR DESCRIPTION
This fixes timing bugs when Unit Testing using the default
driver. According to @bbalser, the default driver should
only be used in testing scenarios. This change did not
cause any tests in smartcitiesdata/smartcitiesdata to fail.

Also fixes a bug in Brook.Test.clear_dataset_details/2

co-authored-by: Tony Brock <abrock17@gmail.com>